### PR TITLE
fix(core): add missing lodash dependency to quicktype-core

### DIFF
--- a/build/quicktype-core/package-lock.json
+++ b/build/quicktype-core/package-lock.json
@@ -52,9 +52,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.10.61",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
-            "integrity": "sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q==",
+            "version": "8.10.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.10.tgz",
+            "integrity": "sha512-p3W/hFzQs76RlYRIZsZc5a9bht6m0TspmWYYbKhRswmLnwj9fsE40EbuGifeu/XWR/c0UJQ1DDbvTxIsm/OOAA==",
             "dev": true
         },
         "@types/pako": {
@@ -70,12 +70,13 @@
             "dev": true
         },
         "@types/readable-stream": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.0.tgz",
-            "integrity": "sha512-c0+lRjSeBakp3YJaP4BixI+sWWO5JFsG3wKAlUNl2olBB5sbXY8rgRbFbBwLkuuX3xSxNqpCZzeROJzMlsCdig==",
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
+            "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "*",
+                "safe-buffer": "*"
             }
         },
         "@types/urijs": {
@@ -476,6 +477,11 @@
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
             }
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "magic-string": {
             "version": "0.22.5",

--- a/build/quicktype-core/package.in.json
+++ b/build/quicktype-core/package.in.json
@@ -13,18 +13,19 @@
         "tslint": "tslint --project ."
     },
     "dependencies": {
+        "@mark.probst/unicode-properties": "~1.1.0",
+        "browser-or-node": "^1.2.1",
         "collection-utils": "^1.0.1",
         "is-url": "^1.2.4",
+        "isomorphic-fetch": "^2.2.1",
         "js-base64": "^2.4.3",
+        "lodash": "^4.17.10",
         "pako": "^1.0.6",
         "pluralize": "^7.0.0",
-        "@mark.probst/unicode-properties": "~1.1.0",
+        "readable-stream": "2.3.0",
         "urijs": "^1.19.1",
         "wordwrap": "^1.0.0",
-        "yaml": "^1.5.0",
-        "readable-stream": "2.3.0",
-        "isomorphic-fetch": "^2.2.1",
-        "browser-or-node": "^1.2.1"
+        "yaml": "^1.5.0"
     },
     "devDependencies": {
         "@types/urijs": "^1.19.8",
@@ -38,7 +39,9 @@
         "@types/readable-stream": "2.3.9",
         "@types/browser-or-node": "^1.2.0"
     },
-    "files": ["dist/**"],
+    "files": [
+        "dist/**"
+    ],
     "browser": {
         "fs": false
     }


### PR DESCRIPTION
`quicktype-core` depends on `lodash`
https://github.com/quicktype/quicktype/blob/4a8362bc1a7a568d1d9a27320494b372f9f086fc/src/quicktype-core/language/Dart.ts#L39 but this is no listed in the package.json